### PR TITLE
set `flex-direction` to `column`

### DIFF
--- a/src/components/MainLayout.jsx
+++ b/src/components/MainLayout.jsx
@@ -9,7 +9,7 @@ import Footer from './Footer';
 const MainLayout = ({ showHeader = true, showFooter = true, children }) =>
   <div className='main-layout'>
     {showHeader ? <Header /> : null}
-    <div className='grow-1'>
+    <div className='flex-column grow-1'>
       {children}
     </div>
     {showFooter ? <Footer /> : null}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -26,5 +26,6 @@ html, body, #main {
   .grow-#{$i} {
     display: flex;
     flex-grow: $i;
+    flex-direction: column;
   }
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -22,10 +22,13 @@ html, body, #main {
   }
 }
 
+.flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
 @for $i from 1 through 6 {
   .grow-#{$i} {
-    display: flex;
     flex-grow: $i;
-    flex-direction: column;
   }
 }


### PR DESCRIPTION
This fixes the viewer-count heading from appearing to the left of the streams grid.