### PR TITLE
sanitize channel name

### DIFF
--- a/src/api/websocket.js
+++ b/src/api/websocket.js
@@ -121,6 +121,10 @@ export default function makeWebSocketServer(server) {
     async setStream(id, channel, service) {
       const ws = rustler_sockets.get(id);
       try {
+        // basic channel name sanitization
+        if (!/^[a-zA-Z0-9\-_]{1,64}$/.test(channel)){
+          channel = null;
+        }
         // get our rustler and their stream from the db
         const [ rustler ] = await Rustler.findAll({
           where: { id },


### PR DESCRIPTION
At the moment you can
 - create arbitrarily long channel names (only capped by URL-length)
 - use all kinds of "invalid" channel names, including e.g. emojis
 - use url-encoded control charaters (%0d%0a) to create links on the overrustle "front page" that cannot increase in viewer-number

This would fix all of the above. Regex should be reviewed...