### PR TITLE
set `JOBS` default to the core count

### DIFF
--- a/api/deps.sh
+++ b/api/deps.sh
@@ -1,6 +1,11 @@
 #! /bin/bash
 
-JOBS=8
+# Set the `JOBS` environment variable to configure how many `make` jobs can be
+# executed simultaneously. If `JOBS` is not set, then the default is the number
+# of cores on the system.
+nproc=$(getconf _NPROCESSORS_ONLN)
+JOBS=${JOBS:-$nproc}
+
 BASE_DIR="$(/bin/pwd)/third-party"
 
 set -e


### PR DESCRIPTION
I don't have 8 cores on my laptop, so whenever I want to build the
backend I have to manually change `api/deps.sh` to reduce the `JOBS`
count. This patch sets the default `JOBS` value to the number of cores
on the system, and allows one to configure this value via the `JOBS`
environment variable.